### PR TITLE
Include  astromatic-source-extractor in osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -44,6 +44,7 @@ arrow-odbc
 asio
 astra-toolbox
 astroid
+astromatic-source-extractor
 astropy-healpix
 astroscrappy
 asv


### PR DESCRIPTION
Ask to add support for osx-arm64 as suggested in https://conda-forge.org/blog/2020/10/29/macos-arm64/#how-to-add-a-osx-arm64-build-to-a-feedstock